### PR TITLE
Add js extension if no extension available

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -121,6 +121,11 @@ const prepare = async (logger) => {
     let filepath;
     if (entry) {
       filepath = path.isAbsolute(entry) ? path.resolve(entry) : path.resolve(cwd, entry);
+
+      // ensure a file extension is present. If not, automatically add .js
+      if (!path.extname(entry)) {
+        filepath = `${filepath}.js`;
+      }
     } else {
       filepath = path.resolve(cwd, sketchDirectory, generateFileName(prefix));
     }


### PR DESCRIPTION
As per https://github.com/mattdesl/canvas-sketch/issues/33, adds a `.js` extension if no extension is provided.