### PR TITLE
Pass `context.canvas` to `OrbitControls` in threejs template

### DIFF
--- a/src/templates/three.js
+++ b/src/templates/three.js
@@ -30,7 +30,7 @@ const sketch = ({ context }) => {
   camera.lookAt(new THREE.Vector3());
 
   // Setup camera controller
-  const controls = new THREE.OrbitControls(camera);
+  const controls = new THREE.OrbitControls(camera, context.canvas);
 
   // Setup your scene
   const scene = new THREE.Scene();


### PR DESCRIPTION
This prevents right-click hijacking on other DOM elements on the page. This doesn't actually fix the problem of wanting to directly inspect the `canvas` element from a right-click, but can help with inspecting other things on the page.