### PR TITLE
Throw the runtime error if the terser minification fails

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -185,25 +185,26 @@ const start = async (args, overrides = {}) => {
     const buffer = await bundleAsync(bundler);
     let code = buffer.toString();
     if (compressJS) {
-      try {
-        code = terser.minify(code, {
-          sourceMap: true,
-          output: { comments: false },
-          compress: {
-            keep_infinity: true,
-            pure_getters: true
-          },
-          warnings: true,
-          ecma: 5,
-          toplevel: false,
-          mangle: {
-            properties: false
-          }
-        }).code;
-      } catch (err) {
+      const { code : minifiedCode, error } = terser.minify(code, {
+        sourceMap: true,
+        output: { comments: false },
+        compress: {
+          keep_infinity: true,
+          pure_getters: true
+        },
+        warnings: true,
+        ecma: 5,
+        toplevel: false,
+        mangle: {
+          properties: false
+        }
+      });
+      // Check if an error occurred during the runtime
+      if (!minifiedCode) {
         logger.error('Could not compress JS bundle');
-        throw new Error(err);
+        throw error
       }
+      code = minifiedCode;
     }
 
     // In --stdout mode, just output the code


### PR DESCRIPTION
Hi,

I encountered a first unexpected issue when I tried to build my sketch with this command line:

`canvas-sketch --build mySketch.js  --dir public/`

```log
TypeError: Cannot read property 'length' of undefined

    at logFile (/node/v9.3.0/lib/node_modules/canvas-sketch-cli/src/index.js:216:54)
    at ...
```

And it's because `terser.minify().code` returned `undefined` when an error occurs.
Indeed, the runtime errors are saved into `result.error` and don't trigger the try/catch who wrap it.
See : https://github.com/terser-js/terser#api-reference 

So I tried here to log the error triggered by terser : 

```
  Error: Could not compress JS bundle  

SyntaxError: Unexpected token: punc ())

    at Z.get (node/v9.3.0/lib/node_modules/canvas-sketch-cli/node_modules/terser/dist/bundle.min.js:1:525)
    at ...
```

There is probably a better way to log the error. If you want, let me know how I should update it!

