### PR TITLE
Add JSDoc comment for "context" autocomplete

### DIFF
--- a/src/templates/default.js
+++ b/src/templates/default.js
@@ -5,10 +5,16 @@ const settings = {
 };
 
 const sketch = () => {
-  return ({ context, width, height }) => {
+  
+  /**
+   * @param {{context: CanvasRenderingContext2D}} 
+   */
+  const render = ({ context, width, height }) => {
     context.fillStyle = 'white';
     context.fillRect(0, 0, width, height);
   };
+  
+  return render;
 };
 
 canvasSketch(sketch, settings);


### PR DESCRIPTION
May or may not be helpful depending on other people's environments, but I found myself doing this in each new project so that I get autocomplete of the "context" parameter in VSCode
![Screen Shot 2021-01-05 at 11 11 46 PM](https://user-images.githubusercontent.com/4997929/103728245-6f492a80-4fab-11eb-96a8-6b20721b617b.png)
