### PR TITLE
Fixes errors on stream-end

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -175,7 +175,6 @@ module.exports = (opt = {}) => {
     let filename;
     let responded = false;
     let fileWritePromise = Promise.resolve();
-    const usingStream = Boolean(isStreaming && currentStream);
     busboy.once('file', (field, file, name, enc, mimeType) => {
       fileWritePromise = new Promise((resolve, reject) => {
         mkdirp(output, err => {
@@ -184,6 +183,7 @@ module.exports = (opt = {}) => {
           filename = path.basename(name);
           const filePath = path.join(output, filename);
           const curFileName = filename;
+          const usingStream = Boolean(isStreaming && currentStream);
 
           if (usingStream) {
             if (mimeType && mimeType !== currentStream.encoding) {
@@ -224,6 +224,7 @@ module.exports = (opt = {}) => {
       fileWritePromise
         .then(() => {
           if (responded) return;
+          const usingStream = Boolean(isStreaming && currentStream);
           responded = true;
           respond(res, {
             filename: filename,

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -74,9 +74,10 @@ module.exports = (opt = {}) => {
     if (currentStream) {
       p = currentStream.end();
     }
-    currentStream = null;
-    currentStreamFilename = null;
-    return p.catch(err => {
+    return p.then(() => {
+      currentStream = null;
+      currentStreamFilename = null;
+    }).catch(err => {
       console.error(err);
     });
   }


### PR DESCRIPTION
When trying to save a stream, I consistently came across a bug that would stop the server. Luckily the streams would always save, but I'd have to remember to restart the server afterward.

The error was that `encoding` couldn't be read on `currentStream`, but I noticed that there was a check for `currentStream` stored in `usingStream`. I then realized that this check is made before running a few bits of async code (`busyboy.once`, `mkdirp`, and then later after `fileWritePromise`).

I also realized that this is interacting with the `handleStreamStop` and `stopCurrentStream` functions. When the last frame is being process, `stopCurrentStream` sets the `currentStream` and `currentStreamFilename` global values to null, which keep `handleSaveBlob` to finish its operation. I've updated this to only wipe those values after the stream has ended. This keeps it from dropping the last sent frame.